### PR TITLE
feat: add About & Help section with Terms and Privacy

### DIFF
--- a/Zap.xcodeproj/project.pbxproj
+++ b/Zap.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A2AF7C172C9ED0B6002DAC5A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				AboutHelpView.swift,
 				AppearanceSettingsView.swift,
 				AudioNoteView.swift,
 				AudioPlayerInlineView.swift,
@@ -35,8 +36,10 @@
 				ImageFullscreenView.swift,
 				ImagePicker.swift,
 				NoteRowView.swift,
+				PrivacyPolicyView.swift,
 				SavedNotesView.swift,
 				SettingsView.swift,
+				TermsOfServiceView.swift,
 				TextNoteView.swift,
 				VideoThumbnailView.swift,
 			);

--- a/Zap/Views/AboutHelpView.swift
+++ b/Zap/Views/AboutHelpView.swift
@@ -1,0 +1,61 @@
+//
+//  AboutHelpView.swift
+//  Zap
+//
+//  Created by Zigao Wang on 9/28/24.
+//
+
+import SwiftUI
+
+struct AboutHelpView: View {
+    @Environment(\.openURL) var openURL
+    
+    var body: some View {
+        List {
+            Section(header: Text("About")) {
+                HStack {
+                    Text("App Version")
+                    Spacer()
+                    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")
+                        .foregroundColor(.secondary)
+                }
+                
+                NavigationLink("Terms of Service", destination: TermsOfServiceView())
+                NavigationLink("Privacy Policy", destination: PrivacyPolicyView())
+            }
+            
+            Section(header: Text("Help")) {
+                Button("FAQs") {
+                    if let url = URL(string: "https://github.com/ZigaoWang/Zap") {
+                        openURL(url)
+                    }
+                }
+                
+                Button("Contact Support") {
+                    if let url = URL(string: "mailto:a@zigao.wang") {
+                        openURL(url)
+                    }
+                }
+            }
+            
+            Section(header: Text("Feedback")) {
+                Button("Rate the App") {
+                    if let url = URL(string: "https://apps.apple.com/app/idAPP_ID") {
+                        openURL(url)
+                    }
+                }
+            }
+            
+            Section(header: Text("Credits")) {
+                Button("Created by Zigao Wang") {
+                    openURL(URL(string: "https://zigao.wang")!)
+                }
+                
+                Button("Open Source on GitHub") {
+                    openURL(URL(string: "https://github.com/ZigaoWang/Zap")!)
+                }
+            }
+        }
+        .navigationTitle("About & Help")
+    }
+}

--- a/Zap/Views/HomeView.swift
+++ b/Zap/Views/HomeView.swift
@@ -45,9 +45,11 @@ struct HomeView: View {
             .navigationTitle("Zap")
             .sheet(isPresented: $showingImagePicker) {
                 ImagePicker(sourceType: .photoLibrary)
+                    .environmentObject(viewModel)
             }
             .sheet(isPresented: $showingCameraPicker) {
                 ImagePicker(sourceType: .camera)
+                    .environmentObject(viewModel)
             }
             .sheet(isPresented: $showingTextNote) {
                 TextNoteView()

--- a/Zap/Views/PrivacyPolicyView.swift
+++ b/Zap/Views/PrivacyPolicyView.swift
@@ -1,0 +1,70 @@
+//
+//  PrivacyPolicyView.swift
+//  Zap
+//
+//  Created by Zigao Wang on 9/28/24.
+//
+
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    var body: some View {
+        ScrollView {
+            Text(privacyPolicy)
+                .padding()
+        }
+        .navigationTitle("Privacy Policy")
+    }
+    
+    private var privacyPolicy: String {
+        """
+        Privacy Policy for Zap App
+
+        1. Information Collection and Use
+        We collect several different types of information for various purposes to provide and improve our Service to you.
+
+        2. Types of Data Collected
+        Personal Data
+        While using our Service, we may ask you to provide us with certain personally identifiable information that can be used to contact or identify you ("Personal Data"). Personally identifiable information may include, but is not limited to:
+        - Email address
+        - First name and last name
+        - Cookies and Usage Data
+
+        Usage Data
+        We may also collect information that your browser sends whenever you visit our Service or when you access the Service by or through a mobile device ("Usage Data").
+
+        3. Use of Data
+        Zap uses the collected data for various purposes:
+        - To provide and maintain our Service
+        - To notify you about changes to our Service
+        - To allow you to participate in interactive features of our Service when you choose to do so
+        - To provide customer support
+        - To gather analysis or valuable information so that we can improve our Service
+        - To monitor the usage of our Service
+        - To detect, prevent and address technical issues
+
+        4. Transfer of Data
+        Your information, including Personal Data, may be transferred to — and maintained on — computers located outside of your state, province, country or other governmental jurisdiction where the data protection laws may differ from those of your jurisdiction.
+
+        5. Disclosure of Data
+        We may disclose your Personal Data in the good faith belief that such action is necessary to:
+        - To comply with a legal obligation
+        - To protect and defend the rights or property of Zap
+        - To prevent or investigate possible wrongdoing in connection with the Service
+        - To protect the personal safety of users of the Service or the public
+        - To protect against legal liability
+
+        6. Security of Data
+        The security of your data is important to us but remember that no method of transmission over the Internet or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your Personal Data, we cannot guarantee its absolute security.
+
+        7. Changes to This Privacy Policy
+        We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.
+
+        8. Contact Us
+        If you have any questions about this Privacy Policy, please contact us:
+        - By email: a@zigao.wang
+
+        Last updated: September 28, 2024
+        """
+    }
+}

--- a/Zap/Views/SettingsView.swift
+++ b/Zap/Views/SettingsView.swift
@@ -14,7 +14,9 @@ struct SettingsView: View {
                 NavigationLink(destination: AppearanceSettingsView()) {
                     SettingsRowView(title: "Appearance", icon: "paintbrush.fill")
                 }
-                // Add more NavigationLinks for other settings categories here
+                NavigationLink(destination: AboutHelpView()) {
+                                    SettingsRowView(title: "About & Help", icon: "info.circle.fill")
+                }
             }
             .navigationTitle("Settings")
         }

--- a/Zap/Views/TermsOfServiceView.swift
+++ b/Zap/Views/TermsOfServiceView.swift
@@ -1,0 +1,50 @@
+//
+//  TermsOfServiceView.swift
+//  Zap
+//
+//  Created by Zigao Wang on 9/28/24.
+//
+
+import SwiftUI
+
+struct TermsOfServiceView: View {
+    var body: some View {
+        ScrollView {
+            Text(termsOfService)
+                .padding()
+        }
+        .navigationTitle("Terms of Service")
+    }
+    
+    private var termsOfService: String {
+        """
+        Terms of Service for Zap App
+
+        1. Acceptance of Terms
+        By using the Zap app, you agree to these Terms of Service. If you disagree with any part of the terms, you may not use our app.
+
+        2. Use License
+        Permission is granted to temporarily download one copy of the app for personal, non-commercial transitory viewing only.
+
+        3. Disclaimer
+        The app is provided on an 'as is' basis. We make no warranties, expressed or implied, and hereby disclaim and negate all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
+
+        4. Limitations
+        In no event shall we or our suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the app.
+
+        5. Revisions and Errata
+        The materials appearing in the Zap app could include technical, typographical, or photographic errors. We do not warrant that any of the materials in this app are accurate, complete or current.
+
+        6. Links
+        We have not reviewed all of the sites linked to our app and are not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by us of the site. Use of any such linked website is at the user's own risk.
+
+        7. Modifications
+        We may revise these terms of service for the app at any time without notice. By using this app you are agreeing to be bound by the then current version of these terms of service.
+
+        8. Governing Law
+        These terms and conditions are governed by and construed in accordance with the laws of [Your Country/State] and you irrevocably submit to the exclusive jurisdiction of the courts in that State or location.
+
+        Last updated: September 28, 2024
+        """
+    }
+}


### PR DESCRIPTION
- Implement AboutHelpView with app info and links
- Add TermsOfServiceView and PrivacyPolicyView
- Update HomeView to correctly pass viewModel to ImagePicker
- Ensure compatibility with earlier iOS versions