### PR TITLE
fix: Save notes to file system and fix audio playback issues

### DIFF
--- a/Zap/Models/NoteItem.swift
+++ b/Zap/Models/NoteItem.swift
@@ -15,12 +15,12 @@ struct NoteItem: Identifiable, Codable {
 
 enum NoteType: Codable {
     case text(String)
-    case audio(URL, TimeInterval)
-    case photo(URL)
-    case video(URL, TimeInterval)
+    case audio(String, TimeInterval)
+    case photo(String)
+    case video(String, TimeInterval)
 
     private enum CodingKeys: String, CodingKey {
-        case type, content, url, duration
+        case type, content, fileName, duration
     }
 
     enum NoteTypeCoding: String, Codable {
@@ -35,16 +35,16 @@ enum NoteType: Codable {
             let content = try container.decode(String.self, forKey: .content)
             self = .text(content)
         case .audio:
-            let url = try container.decode(URL.self, forKey: .url)
+            let fileName = try container.decode(String.self, forKey: .fileName)
             let duration = try container.decode(TimeInterval.self, forKey: .duration)
-            self = .audio(url, duration)
+            self = .audio(fileName, duration)
         case .photo:
-            let url = try container.decode(URL.self, forKey: .url)
-            self = .photo(url)
+            let fileName = try container.decode(String.self, forKey: .fileName)
+            self = .photo(fileName)
         case .video:
-            let url = try container.decode(URL.self, forKey: .url)
+            let fileName = try container.decode(String.self, forKey: .fileName)
             let duration = try container.decode(TimeInterval.self, forKey: .duration)
-            self = .video(url, duration)
+            self = .video(fileName, duration)
         }
     }
 
@@ -54,16 +54,16 @@ enum NoteType: Codable {
         case .text(let content):
             try container.encode(NoteTypeCoding.text, forKey: .type)
             try container.encode(content, forKey: .content)
-        case .audio(let url, let duration):
+        case .audio(let fileName, let duration):
             try container.encode(NoteTypeCoding.audio, forKey: .type)
-            try container.encode(url, forKey: .url)
+            try container.encode(fileName, forKey: .fileName)
             try container.encode(duration, forKey: .duration)
-        case .photo(let url):
+        case .photo(let fileName):
             try container.encode(NoteTypeCoding.photo, forKey: .type)
-            try container.encode(url, forKey: .url)
-        case .video(let url, let duration):
+            try container.encode(fileName, forKey: .fileName)
+        case .video(let fileName, let duration):
             try container.encode(NoteTypeCoding.video, forKey: .type)
-            try container.encode(url, forKey: .url)
+            try container.encode(fileName, forKey: .fileName)
             try container.encode(duration, forKey: .duration)
         }
     }

--- a/Zap/Views/AudioNoteView.swift
+++ b/Zap/Views/AudioNoteView.swift
@@ -14,19 +14,19 @@ struct AudioNoteView: View {
     @State private var isRecording = false
     @State private var audioRecorder: AVAudioRecorder?
     @State private var audioFilename: URL?
-    
+
     var body: some View {
         VStack {
             if isRecording {
-                Text("正在录音...")
+                Text("Recording...")
                     .foregroundColor(.red)
                     .padding()
             } else {
-                Text("录音")
+                Text("Tap to Record")
                     .foregroundColor(.green)
                     .padding()
             }
-            
+
             Button(action: {
                 if isRecording {
                     stopRecording()
@@ -40,60 +40,53 @@ struct AudioNoteView: View {
                     .foregroundColor(isRecording ? .red : .green)
             }
             .padding()
-            
+
             Spacer()
         }
-        .navigationTitle("新录音笔记")
+        .navigationTitle("New Audio Note")
         .navigationBarTitleDisplayMode(.inline)
     }
-    
+
     func startRecording() {
         let audioSession = AVAudioSession.sharedInstance()
         do {
             try audioSession.setCategory(.record, mode: .default, options: [])
             try audioSession.setActive(true)
-            
+
             let documentsDirectory = FileManager.default.urls(
                 for: .documentDirectory, in: .userDomainMask
             )[0]
             let filename = UUID().uuidString + ".m4a"
             let fileURL = documentsDirectory.appendingPathComponent(filename)
             audioFilename = fileURL
-            
+
             let settings: [String: Any] = [
                 AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                 AVSampleRateKey: 12000,
                 AVNumberOfChannelsKey: 1,
                 AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
             ]
-            
+
             audioRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
             audioRecorder?.record()
-            
+
             isRecording = true
         } catch {
-            print("录音失败: \(error.localizedDescription)")
+            print("Recording failed: \(error.localizedDescription)")
         }
     }
-    
+
     func stopRecording() {
         audioRecorder?.stop()
         isRecording = false
         if let url = audioFilename {
-            // 获取持续时间
+            let fileName = url.lastPathComponent
             let asset = AVURLAsset(url: url)
             let duration = CMTimeGetSeconds(asset.duration)
-            viewModel.addAudioNote(url: url, duration: duration)
+            viewModel.addAudioNote(fileName: fileName, duration: duration)
         }
         audioRecorder = nil
         audioFilename = nil
         presentationMode.wrappedValue.dismiss()
-    }
-}
-
-struct AudioNoteView_Previews: PreviewProvider {
-    static var previews: some View {
-        AudioNoteView()
-            .environmentObject(NotesViewModel())
     }
 }

--- a/Zap/Views/AudioPlayerView.swift
+++ b/Zap/Views/AudioPlayerView.swift
@@ -11,12 +11,12 @@ import AVFoundation
 struct AudioPlayerView: View {
     let url: URL
     let duration: TimeInterval
-    
+
     @State private var isPlaying = false
     @State private var progress: Double = 0
     @State private var player: AVAudioPlayer?
     @State private var errorMessage: String?
-    
+
     var body: some View {
         VStack {
             if let errorMessage = errorMessage {
@@ -28,7 +28,7 @@ struct AudioPlayerView: View {
                         Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
                             .font(.title)
                     }
-                    
+
                     Slider(value: $progress, in: 0...duration) { editing in
                         if !editing {
                             player?.currentTime = progress
@@ -43,12 +43,16 @@ struct AudioPlayerView: View {
             player?.stop()
         }
     }
-    
-    private func setupPlayer() {
+
+    func setupPlayer() {
         do {
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try audioSession.setActive(true)
+
             player = try AVAudioPlayer(contentsOf: url)
             player?.prepareToPlay()
-            
+
             Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
                 if let player = player {
                     progress = player.currentTime
@@ -59,10 +63,11 @@ struct AudioPlayerView: View {
             }
         } catch {
             errorMessage = "Error setting up player: \(error.localizedDescription)"
+            print("Error setting up player: \(error)")
         }
     }
-    
-    private func togglePlayPause() {
+
+    func togglePlayPause() {
         if isPlaying {
             player?.pause()
         } else {

--- a/Zap/Views/FullScreenMediaView.swift
+++ b/Zap/Views/FullScreenMediaView.swift
@@ -17,9 +17,11 @@ struct FullScreenMediaView: View {
             Color.black.edgesIgnoringSafeArea(.all)
 
             switch note.type {
-            case .photo(let url):
+            case .photo(let fileName):
+                let url = getDocumentsDirectory().appendingPathComponent(fileName)
                 PhotoFullScreenView(url: url)
-            case .video(let url, _):
+            case .video(let fileName, _):
+                let url = getDocumentsDirectory().appendingPathComponent(fileName)
                 VideoFullScreenView(url: url)
             default:
                 EmptyView()
@@ -38,6 +40,10 @@ struct FullScreenMediaView: View {
                 Spacer()
             }
         }
+    }
+
+    private func getDocumentsDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }
 }
 
@@ -64,11 +70,6 @@ struct VideoFullScreenView: View {
 
     var body: some View {
         VideoPlayer(player: AVPlayer(url: url))
-    }
-}
-
-struct FullScreenMediaView_Previews: PreviewProvider {
-    static var previews: some View {
-        FullScreenMediaView(note: NoteItem(id: UUID(), timestamp: Date(), type: .photo(URL(fileURLWithPath: ""))), isPresented: .constant(true))
+            .edgesIgnoringSafeArea(.all)
     }
 }

--- a/Zap/Views/ImagePicker.swift
+++ b/Zap/Views/ImagePicker.swift
@@ -39,9 +39,8 @@ struct ImagePicker: UIViewControllerRepresentable {
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
             if let image = info[.originalImage] as? UIImage {
                 let imageURL = saveImageToDocuments(image)
-                parent.viewModel.addPhotoNote(url: imageURL)
-                
-                // Only save to album if the source is camera
+                parent.viewModel.addPhotoNote(fileName: imageURL.lastPathComponent)
+
                 if parent.sourceType == .camera {
                     saveToAlbum(image: image)
                 }
@@ -49,14 +48,13 @@ struct ImagePicker: UIViewControllerRepresentable {
                 let savedVideoURL = saveVideoToDocuments(videoURL)
                 let asset = AVAsset(url: savedVideoURL)
                 let duration = asset.duration.seconds
-                parent.viewModel.addVideoNote(url: savedVideoURL, duration: duration)
-                
-                // Only save to album if the source is camera
+                parent.viewModel.addVideoNote(fileName: savedVideoURL.lastPathComponent, duration: duration)
+
                 if parent.sourceType == .camera {
                     saveToAlbum(videoURL: videoURL)
                 }
             }
-            
+
             parent.presentationMode.wrappedValue.dismiss()
         }
 
@@ -85,7 +83,7 @@ struct ImagePicker: UIViewControllerRepresentable {
         private func saveToAlbum(image: UIImage? = nil, videoURL: URL? = nil) {
             PHPhotoLibrary.requestAuthorization { status in
                 guard status == .authorized else { return }
-                
+
                 PHPhotoLibrary.shared().performChanges {
                     if let image = image {
                         PHAssetChangeRequest.creationRequestForAsset(from: image)

--- a/Zap/Views/NoteRowView.swift
+++ b/Zap/Views/NoteRowView.swift
@@ -17,9 +17,7 @@ struct NoteRowView: View {
                 Text(note.timestamp, style: .time)
                     .font(.caption)
                     .foregroundColor(.secondary)
-                
                 Spacer()
-                
                 Text(formattedDuration)
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -29,15 +27,18 @@ struct NoteRowView: View {
             case .text(let content):
                 Text(content)
                     .lineLimit(3)
-            case .audio(let url, let duration):
+            case .audio(let fileName, let duration):
+                let url = getDocumentsDirectory().appendingPathComponent(fileName)
                 AudioPlayerView(url: url, duration: duration)
-            case .photo(let url):
+            case .photo(let fileName):
+                let url = getDocumentsDirectory().appendingPathComponent(fileName)
                 Image(uiImage: UIImage(contentsOfFile: url.path) ?? UIImage())
                     .resizable()
                     .scaledToFit()
                     .frame(height: 100)
                     .onTapGesture { showFullScreen = true }
-            case .video(let url, _):
+            case .video(let fileName, _):
+                let url = getDocumentsDirectory().appendingPathComponent(fileName)
                 VideoThumbnailView(videoURL: url)
                     .onTapGesture { showFullScreen = true }
             }
@@ -47,7 +48,7 @@ struct NoteRowView: View {
             FullScreenMediaView(note: note, isPresented: $showFullScreen)
         }
     }
-    
+
     private var formattedDuration: String {
         switch note.type {
         case .text:
@@ -58,10 +59,8 @@ struct NoteRowView: View {
             return ""
         }
     }
-}
 
-struct NoteRowView_Previews: PreviewProvider {
-    static var previews: some View {
-        NoteRowView(note: NoteItem(id: UUID(), timestamp: Date(), type: .text("Sample text note")))
+    private func getDocumentsDirectory() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }
 }


### PR DESCRIPTION
- Implemented file-based storage for notes using JSON serialization
  - Notes are now saved to and loaded from 'notes.json' in the app's documents directory
  - This change prevents issues related to exceeding UserDefaults size limitations, ensuring data persistence for photos and videos across app launches

- Corrected AVAudioSession configuration for audio playback
  - Updated `AudioPlayerView` to use `.playAndRecord` category with `.defaultToSpeaker` option
  - Removed incorrect use of `overrideOutputAudioPort`, which caused OSStatus error -50
  - Ensured audio playback uses the device's speaker by default

- Modified media handling to use file names instead of full paths
  - Adjusted `NoteItem` model to store media file names instead of full file paths
  - Reconstructed full file paths at runtime to access media files
  - Updated views (`NoteRowView`, `FullScreenMediaView`, etc.) to handle the new file path construction for audio, photo, and video notes

- Fixed issue where media files were not deleted when notes were removed
  - Implemented deletion of associated media files when notes are deleted
  - This prevents unused files from taking up storage space on the user's device

- Enhanced error handling and logging
  - Improved error messages for easier debugging
  - Added print statements to log errors encountered during audio playback setup

- Adjusted AVAudioSession configurations
  - Ensured consistency in audio session configurations across the app
  - Verified that categories and options are set appropriately for recording and playback